### PR TITLE
Add hints for PDO functions

### DIFF
--- a/phpdata/php-predefined.js
+++ b/phpdata/php-predefined.js
@@ -233,6 +233,11 @@ define(function (require, exports, module) {
         'odbc_primarykeys|odbc_procedurecolumns|odbc_procedures|odbc_result|odbc_result_all|odbc_rollback|odbc_setoption|odbc_specialcolumns|' +
         'odbc_statistics|odbc_tableprivileges|odbc_tables';
 
+    var pdoFunctions =
+        'beginTransaction|commit|errorCode|errorInfo|exec|getAttribute|getAvailableDrivers|inTransaction|lastInsertId|prepare|query|quote|' +
+        'rollBack|setAttribute|bindColumn|bindParam|bindValue|closeCursor|columnCount|debugDumpParams|errorCode|errorInfo|execute|fetch|' +
+        'fetchAll|fetchColumn|fetchObject|getAttribute|getColumnMeta|nextRowset|rowCount|setAttribute|setFetchMode';
+
     // database - vendor specific
 
     var cubridFunctions =


### PR DESCRIPTION
Hey,
I don't know if this is done right but I wanted to add support for PDO functions as I need those sometimes. So I took all but "__construct" from here: http://php.net/manual/de/book.pdo.php

I know this won't work right now, but I saw that you splitted those functions in the 1.1.0 branch so I did the same for the PDO functions.

Just tell me if something is wrong :)

Greets,
Dominic
